### PR TITLE
Download appropriate binary for aarch64 and amd64

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -30,7 +30,13 @@ commands:
               ARCH="x86_64"
             fi
 
-            curl -L https://github.com/a8m/envsubst/releases/download/<< parameters.version >>/envsubst-`uname -s`-$ARCH -o envsubst
+            RES_CODE=$(curl -L https://github.com/a8m/envsubst/releases/download/<< parameters.version >>/envsubst-`uname -s`-$ARCH -o envsubst)
+
+            if [[ $RES_CODE -ge 400 ]]; then
+              echo "Error: Failed to download envsubst binary from https://github.com/a8m/envsubst/releases/download/<< parameters.version >>/envsubst-`uname -s`-$ARCH. Response code: $RES_CODE"
+              exit 1
+            fi
+            
             chmod +x envsubst
             $SUDO mv envsubst << parameters.install-dir >>
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -12,7 +12,7 @@ commands:
           Installing version of envsubst.
           https://github.com/a8m/envsubst/releases
         type: string
-        default: v1.1.0
+        default: v1.4.2
       install-dir:
         description: Directory in which to install the envsubst command
         type: string
@@ -23,7 +23,14 @@ commands:
           command: |
             if [[ $EUID == 0 ]]; then export SUDO=""; else export SUDO="sudo"; fi
 
-            curl -L https://github.com/a8m/envsubst/releases/download/<< parameters.version >>/envsubst-`uname -s`-`uname -m` -o envsubst
+            ARCH=$(uname -m)
+            if [[ "$ARCH" == "aarch64" ]]; then
+              ARCH="arm64"
+            elseif [[ "$ARCH" == "amd64" ]]; then
+              ARCH="x86_64"
+            fi
+
+            curl -L https://github.com/a8m/envsubst/releases/download/<< parameters.version >>/envsubst-`uname -s`-$ARCH -o envsubst
             chmod +x envsubst
             $SUDO mv envsubst << parameters.install-dir >>
 


### PR DESCRIPTION
- default to envsubst v1.4.2
- added if statement to map `uname -m` output appropriately 
- exit with error if the binary cannot be downloaded